### PR TITLE
Add eshell-z-change-dir-hook to be run before eshell/cd invocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: generic
 env:
   matrix:
-    - EMACS=emacs24
+    - EMACS=emacs25
     - EMACS=emacs-snapshot
 
 install:
-  - if [ "$EMACS" = 'emacs24' ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
+  - if [ "$EMACS" = 'emacs25' ]; then
+        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
         sudo apt-get -qq update &&
         sudo apt-get -qq -f install &&
-        sudo apt-get -qq install emacs24;
+        sudo apt-get -qq install emacs25;
     fi
   - if [ "$EMACS" = 'emacs-snapshot' ]; then
         sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&


### PR DESCRIPTION
Hi @xuchunyang!  This PR adds a hook called `eshell-z-change-dir-hook` which will be run before `eshell/z` invokes `eshell/cd` to change the directory.  I'd like to use this hook to call `eshell/pushd` with the current directory before it gets changed to the new target directory:

```
(add-hook 'eshell-z-change-dir-hook (lambda () (eshell/pushd (eshell/pwd))))
```

This will allow me to use `popd` to go back to the previous directory I was in before calling `z`.

If you think there's a better way to accomplish this, let me know and I'll be happy to change the code.  Thanks!